### PR TITLE
[CRAI-147] Fix issue with empty progress for speed and accelerate when card sheet is opening

### DIFF
--- a/CarRecognition/Source Files/Common/Views/OvalProgressLayerView.swift
+++ b/CarRecognition/Source Files/Common/Views/OvalProgressLayerView.swift
@@ -72,7 +72,6 @@ extension OvalProgressLayerView {
         progressLayer.lineWidth = lineWidth
         progressLayer.fillColor = UIColor.clear.cgColor
         progressLayer.lineCap = kCALineCapRound
-        progressLayer.strokeEnd = 0
         layer.addSublayer(progressLayer)
     }
     


### PR DESCRIPTION
### Ticket
[CRAI-147](https://netguru.atlassian.net/browse/CRAI-147)


### Task Description
I fixed the issue with progressLayer's strokeEnd being set to 0 after invalidating instantly